### PR TITLE
Use correct menu item

### DIFF
--- a/classes/menu/item/category.php
+++ b/classes/menu/item/category.php
@@ -10,7 +10,6 @@
 
 namespace Nos\BlogNews\News;
 
-use Nos\BlogNews\News\Model_Category;
 use Nos\Menu\Menu_Item_Driver;
 
 class Menu_Item_Category extends Menu_Item_Driver


### PR DESCRIPTION
"Incorrect table name '' [ SELECT `t0`.`cat_id` AS `t0_c0`, `t0`.`cat_title` AS `t0_c1`, `t0`.`cat_virtual_name` AS `t0_c2`, `t0`.`cat_context` AS `t0_c3`, `t0`.`cat_context_common_id` AS `t0_c4`, `t0`.`cat_context_is_main` AS `t0_c5`, `t0`.`cat_parent_id` AS `t0_c6`, `t0`.`cat_sort` AS `t0_c7`, `t0`.`cat_created_at` AS `t0_c8`, `t0`.`cat_updated_at` AS `t0_c9`, `t0`.`cat_created_by_id` AS `t0_c10`, `t0`.`cat_updated_by_id` AS `t0_c11`, `t0`.`category_id` AS `t0_c12` FROM ``AS`t0`WHERE`t0`.`category_id` = '2' LIMIT 1 ] in ..."
